### PR TITLE
fix(vpat.yml): remove configuration override for vpat-label

### DIFF
--- a/.github/workflows/vpat.yml
+++ b/.github/workflows/vpat.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           product-name: axe A11y Metrics POC
           output-file: vpats/{DATE}-{PRODUCT}.md
-          vpat-label: VPAT
       - run: |
           CAT0=$(gh issue list -S "label:CAT0 is:open" --json id -L 1000 --repo dequelabs/a11y-metrics-poc | jq '. | length')
           CAT1=$(gh issue list -S "label:CAT1 is:open" --json id -L 1000 --repo dequelabs/a11y-metrics-poc | jq '. | length')


### PR DESCRIPTION
In light of [this change](https://github.com/dequelabs/action-vpat-report/pull/6/files), which makes `A11Y` the default label that determines which issues are included in the VPAT report, we no longer want to override that value when invoking the VPAT reporting action.

This change removes the configuration override, allowing the default configuration value (`A11Y`) to be applied. This will make the vpat.yml workflow file work as intended for product teams who have yet to set it up and will be coming to this repo for examples in the future.