### PR TITLE
ci(dependabot): monthly version updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
I noticed that a few of the action versions were out of date when setting up another repo. This PR sets up Dependabot to update GitHub actions at a monthly interval.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#about-dependabot-version-updates-for-actions

## PR Checklist

- [x] Followed proper commit messaging
- [ ] Updated documentation, created a DU ticket, or required no documentation change
- [ ] Included new tests (or was unnecessary)
- [ ] Clean axe Pro Automated test
- [ ] Clean axe Pro IGT test