### PR TITLE
chore: remove optional second label from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility_violation.md
+++ b/.github/ISSUE_TEMPLATE/accessibility_violation.md
@@ -2,7 +2,7 @@
 name: Accessibility Violation
 about: Document an accessibility violation to be fixed
 title: '[A11Y] '
-labels: ['A11Y', "PROD: a11y-poc"]
+labels: ['A11Y']
 assignees: ''
 
 ---


### PR DESCRIPTION
This removes an unnecessary label from the issue template. Teams who implement these workflows can choose to modify the issue template to create multiple labels by default, if they want, but only the `A11Y` label will be necessary for a majority of teams.

Closes issue: none

## PR Checklist

- [x] Followed proper commit messaging
- [x] Updated documentation, created a DU ticket, or required no documentation change
- [x] Included new tests (or was unnecessary)
- [x] Clean axe Pro Automated test
- [x] Clean axe Pro IGT test